### PR TITLE
add min and max character limit to tag name

### DIFF
--- a/src/lib/editor-types.ts
+++ b/src/lib/editor-types.ts
@@ -197,7 +197,10 @@ export interface StoryAttribute extends ExternalId {
 
 /** Tag associated with story */
 export interface Tag {
-  /** Name of Tag */
+  /** Name of Tag
+  * @minLength 3
+  * @maxLength 100
+  */
   readonly name: string;
 
   /** Type of entity */


### PR DESCRIPTION
Added minimum and maximum character limit for `name` property of `Tag`

https://github.com/quintype/quintype-validator/issues/43