### PR TITLE
Non empty check

### DIFF
--- a/src/lib/editor-types.ts
+++ b/src/lib/editor-types.ts
@@ -197,7 +197,10 @@ export interface StoryAttribute extends ExternalId {
 
 /** Tag associated with story */
 export interface Tag {
-  /** Name of Tag */
+  /** Name of Tag
+  * @minLength 3
+  * @maxLength 100
+  */
   readonly name: string;
 
   /** Type of entity */

--- a/src/lib/editor-types.ts
+++ b/src/lib/editor-types.ts
@@ -8,10 +8,16 @@ interface StoryMandatoryFields extends ExternalId {
   /** The canonical path to this story */
   readonly slug: string;
 
-  /** List of sections or categories that this story belongs to */
+  /**
+   * List of sections or categories that this story belongs to
+   * @minItems 1
+   */
   readonly sections: ReadonlyArray<IntermediateSection>;
 
-  /** The list of authors (in order) for this content */
+  /**
+   * The list of authors (in order) for this content
+   * @minItems 1
+   */
   readonly authors: ReadonlyArray<IntermediateAuthor>;
 
   /** The type of the story. Use `'text'` for a normal story */
@@ -197,10 +203,11 @@ export interface StoryAttribute extends ExternalId {
 
 /** Tag associated with story */
 export interface Tag {
-  /** Name of Tag
-  * @minLength 3
-  * @maxLength 100
-  */
+  /**
+   * Name of Tag
+   * @minLength 3
+   * @maxLength 100
+   */
   readonly name: string;
 
   /** Type of entity */

--- a/src/lib/stories-writer.spec.ts
+++ b/src/lib/stories-writer.spec.ts
@@ -12,12 +12,12 @@ const streamToArray = require('stream-to-array');
 // tslint:enable:no-var-requires
 
 const commonStoryFields = {
-  authors: [],
+  authors: [{ 'external-id': 'sec-001', name: 'Sec1', email: 'abc@foobar' }],
   body: '<p><Foo/p>',
   'first-published-at': 0,
   'last-published-at': 0,
   'published-at': 0,
-  sections: [],
+  sections: [{ 'external-id': 'sec-001', name: 'Sec1', slug: 'sec' }],
   'story-template': 'text' as 'text',
   summary: 'A story for testing',
   tags: []
@@ -106,7 +106,7 @@ describe('writeStories', () => {
                 [`foo-${i}`]: ['bar']
               }
             },
-            sections: [],
+            sections: [{ 'external-id': 'sec-001', name: 'Sec1', slug: 'sec' }],
             slug: `story-${i}`
           };
         }


### PR DESCRIPTION
Added minimum length limit  for `authors` and `sections` keys inside `Story` intermediate.
https://github.com/quintype/quintype-validator/issues/41